### PR TITLE
 fix some encoding issues in book html

### DIFF
--- a/main.html
+++ b/main.html
@@ -5,7 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
 <title>Six Septembers Reading Group</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="viewport" content="width=device-width">
 <link rel="stylesheet" href="stylesheets/foundation.min.css">
 <link rel="stylesheet" href="stylesheets/main.css">

--- a/main.html
+++ b/main.html
@@ -1137,7 +1137,7 @@ class="description">= &#8220;Timothy is a chinchilla&#8221;</dd></dl>
 <!--l. 338--><p class="noindent" >The second syntactic change replaces the connectives with symbols:
       <ul class="itemize1">
       <li class="itemize"><span 
-class="zptmcm7y-x-x-120">¬ </span>means &#8220;not&#8221;
+class="zptmcm7y-x-x-120">Â¬ </span>means &#8220;not&#8221;
       </li>
       <li class="itemize"><span 
 class="zptmcm7y-x-x-120">&#x2227; </span>means &#8220;and&#8221;
@@ -1190,7 +1190,7 @@ class="ptmb8t-x-x-120">wff</span>, and pronounced
       </li>
       <li 
   class="enumerate" id="x1-12022x2">Any wff preceded by the symbol <span 
-class="zptmcm7y-x-x-120">¬ </span>is a wff.
+class="zptmcm7y-x-x-120">Â¬ </span>is a wff.
       </li>
       <li 
   class="enumerate" id="x1-12024x3">Any two wffs separated by the symbol <span 
@@ -1226,7 +1226,7 @@ class="newline" />Similarly, this just represents&#8220;Quail are a kind of liza
 class="newline" />
       </li>
       <li class="itemize"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">Q </span>(by rule 2 from the previous) <br 
 class="newline" />This represents &#8220;It is not the case that quail are a kind of lizard,&#8221; or equivalently
       &#8220;Quail are not a kind of lizard&#8221; <br 
@@ -1234,18 +1234,18 @@ class="newline" />
       </li>
       <li class="itemize"><span 
 class="zptmcm7m-x-x-120">P </span><span 
-class="zptmcm7y-x-x-120">&#x2192;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2192;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q </span>(by rule 5, from the first and third examples)<br 
 class="newline" />This represents &#8220;If Percy is a cat, then quail are not a kind of lizard.&#8221; <br 
 class="newline" />
       </li>
       <li class="itemize"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
-class="zptmcm7y-x-x-120">&#x2192;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2192;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">) </span>(by rule 4, from the third and fifth examples) <br 
 class="newline" />This represents &#8220;Either quail are not a kind of lizard or else if Percy is a cat,
@@ -1286,13 +1286,13 @@ might stand for some longer elementary proposition, so <span
 class="zptmcm7m-x-x-120">&#x03D5; </span>or <span 
 class="zptmcm7m-x-x-120">&#x03C8; </span>might stand for a more
 complicated formula (e.g. <span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7t-x-x-120">[(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">) </span><span 
-class="zptmcm7y-x-x-120">&#x2192;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2192;Â¬</span><span 
 class="zptmcm7m-x-x-120">R</span><span 
 class="zptmcm7t-x-x-120">]</span>). This notation allows us to rewrite the
 syntactic rules above more tersely as:
@@ -1304,7 +1304,7 @@ syntactic rules above more tersely as:
       <li 
   class="enumerate" id="x1-12036x2">If <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>is a wff, so is <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span>.
       </li>
       <li 
@@ -1362,7 +1362,7 @@ be true or false, the possibilities are often not difficult to list. (In fact, w
 exactly that, although not in tabular format, in our discussion of the semantics of
 &#8220;if-then.&#8221;)
 <!--l. 418--><p class="indent" >  To begin with a very simple truth table, consider the truth value of the expression <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>as
 laid out in table&#x00A0;<a 
 href="#x1-130021">1.1<!--tex4ht:ref: table:notsemantics --></a>. Right away, we can see that <span 
@@ -1377,7 +1377,7 @@ href="#x1-130032">1.2<!--tex4ht:ref: table:semantics --></a>.
  <div class="caption"><table class="caption" 
 ><tr style="vertical-align:baseline;" class="caption"><td class="id">Table&#x00A0;1.1: </td><td  
 class="content">Semantics of <span 
-class="zptmcm7y-x-x-120">¬ </span>(not)</td></tr></table></div><!--tex4ht:label?: x1-130021 -->
+class="zptmcm7y-x-x-120">Â¬ </span>(not)</td></tr></table></div><!--tex4ht:label?: x1-130021 -->
 <div class="tabular"> <table id="TBL-2" class="tabular" 
 cellspacing="0" cellpadding="0"  
 ><colgroup id="TBL-2-1g"><col 
@@ -1387,7 +1387,7 @@ id="TBL-2-2"></colgroup><tr
 class="td11">if <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>is</td><td  style="white-space:nowrap; text-align:left;" id="TBL-2-1-2"  
 class="td11">&#x2026;then <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>is</td>
 </tr><tr 
 class="hline"><td><hr></td><td><hr></td></tr><tr  
@@ -1516,7 +1516,7 @@ class="align-label"><a
                                     </td></tr><tr><td 
 class="align-odd"></td>                                    <td 
 class="align-even"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">T</span> </td>                                                                          <td 
 class="align-label"><a 
  id="x1-13008r38"></a>(1.38)
@@ -1546,7 +1546,7 @@ class="td11">T         </td><td  style="white-space:nowrap; text-align:left;" id
 class="td11">T <span 
 class="zptmcm7y-x-x-120">&#x2228; </span>S </td><td  style="white-space:nowrap; text-align:left;" id="TBL-4-1-4"  
 class="td11"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">T    </span></td><td  style="white-space:nowrap; text-align:left;" id="TBL-4-1-5"  
 class="td11">S        </td></tr><tr 
 class="hline"><td><hr></td><td><hr></td><td><hr></td><td><hr></td><td><hr></td></tr><tr  
@@ -1619,7 +1619,7 @@ matter of rote substitution.
 class="ptmb8t-x-x-120">equivalent </span>if they have the same truth value in all
 circumstances. For example, the formula <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>is equivalent to the formula <span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span>, and
 indeed to the formulas <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
@@ -1648,10 +1648,10 @@ id="TBL-5-5"></colgroup><tr
 class="td11"><span 
 class="zptmcm7m-x-x-120">&#x03D5;   </span></td><td  style="white-space:nowrap; text-align:left;" id="TBL-5-1-2"  
 class="td11"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;  </span></td><td  style="white-space:nowrap; text-align:left;" id="TBL-5-1-3"  
 class="td11"><span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span></td><td  style="white-space:nowrap; text-align:left;" id="TBL-5-1-4"  
 class="td11"><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
@@ -1682,11 +1682,11 @@ class="td11">    </td></tr></table></div>
   </div><hr class="endfloat" />
 <!--l. 495--><p class="indent" >  Having done this, we have also shown that the concepts of <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>and of <span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>have exactly
 the same (logical) meaning. In practical terms, this means that any time one encounters
 the (sub)formula <span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span>, one can replace it with the simpler <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>(and vice versa, of
 course).
@@ -1698,7 +1698,7 @@ class="align">
 class="align-odd"></td>                              <td 
 class="align-even"><span 
 class="zptmcm7t-x-x-120">(</span><span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
@@ -1714,7 +1714,7 @@ class="align-even"></td>                                               <td
 class="align-label"><a 
  id="x1-14005r41"></a>(1.41)                                                             </td></tr></table>
 <!--l. 503--><p class="indent" >  can be simplified by replacing <span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
@@ -1753,14 +1753,14 @@ class="align">
                                   <tr><td 
 class="align-odd"><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
-class="zptmcm7y-x-x-120">&#x22A2;¬¬</span><span 
+class="zptmcm7y-x-x-120">&#x22A2;Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span></td>                                  <td 
 class="align-even"></td>                                  <td 
 class="align-label"><a 
  id="x1-14008r44"></a>(1.44)
                                   </td></tr><tr><td 
 class="align-odd"><span 
-class="zptmcm7y-x-x-120">¬¬</span><span 
+class="zptmcm7y-x-x-120">Â¬Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
 class="zptmcm7y-x-x-120">&#x22A2; </span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span></td>                                  <td 
@@ -1934,11 +1934,11 @@ class="zptmcm7m-x-x-120">P </span><span
 class="zptmcm7y-x-x-120">&#x2192; </span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">)</span><span 
-class="zptmcm7y-x-x-120">&#x2227;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2227;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q </span><span 
 class="zptmcm7y-x-x-120">&#x22A2; </span><span 
 class="zptmcm7t-x-x-120">(</span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">P</span><span 
 class="zptmcm7t-x-x-120">)</span>
       </li>
@@ -1969,7 +1969,7 @@ class="zptmcm7m-x-x-120">P </span><span
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">)</span><span 
-class="zptmcm7y-x-x-120">&#x2227;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2227;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q </span><span 
 class="zptmcm7y-x-x-120">&#x22A2; </span><span 
 class="zptmcm7m-x-x-120">P</span>
@@ -1988,7 +1988,7 @@ class="zptmcm7m-x-x-120">P</span>
       <li class="itemize">(<a 
  id="dx1-14022"></a><span 
 class="ptmb8t-x-x-120">De Morgan&#8217;s theorem</span>) <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2228;</span><span 
@@ -1996,12 +1996,12 @@ class="zptmcm7m-x-x-120">Q</span><span
 class="zptmcm7t-x-x-120">) </span><span 
 class="zptmcm7y-x-x-120">&#x22A2; </span><span 
 class="zptmcm7t-x-x-120">(</span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
-class="zptmcm7y-x-x-120">&#x2227;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2227;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">) </span>and <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2227;</span><span 
@@ -2009,9 +2009,9 @@ class="zptmcm7m-x-x-120">Q</span><span
 class="zptmcm7t-x-x-120">) </span><span 
 class="zptmcm7y-x-x-120">&#x22A2; </span><span 
 class="zptmcm7t-x-x-120">(</span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">P </span><span 
-class="zptmcm7y-x-x-120">&#x2228;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2228;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q</span><span 
 class="zptmcm7t-x-x-120">)</span>
       </li>
@@ -2039,9 +2039,9 @@ class="ptmb8t-x-x-120">contrapositive</span>) <span
 class="zptmcm7m-x-x-120">P </span><span 
 class="zptmcm7y-x-x-120">&#x2192; </span><span 
 class="zptmcm7m-x-x-120">Q </span><span 
-class="zptmcm7y-x-x-120">&#x22A2;¬</span><span 
+class="zptmcm7y-x-x-120">&#x22A2;Â¬</span><span 
 class="zptmcm7m-x-x-120">Q </span><span 
-class="zptmcm7y-x-x-120">&#x2192;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2192;Â¬</span><span 
 class="zptmcm7m-x-x-120">P</span></li></ul>
 <!--l. 584--><p class="noindent" >We could, of course, provide detailed justifications for why these are valid (perhaps
 using truth tables). In the interest of brevity, we&#8217;ll leave that as an exercise for
@@ -2123,12 +2123,12 @@ a more concise way of saying that &#8220;<span
 class="zptmcm7m-x-x-120">b </span>(Paul) is left-handed,&#8221; and &#8220;<span 
 class="zptmcm7m-x-x-120">d </span>(Ringo) is
 left-handed.&#8221; Similarly, we can assert <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">L</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">a</span><span 
 class="zptmcm7t-x-x-120">) </span>and <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">L</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">c</span><span 
@@ -2255,7 +2255,7 @@ class="align-odd"><span
 class="zptmcm7y-x-x-120">&#x2200;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">O</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x,x</span><span 
@@ -2270,7 +2270,7 @@ who is older than Ringo&#8221;):
 class="align">
                                  <tr><td 
 class="align-odd"><span 
-class="zptmcm7y-x-x-120">¬&#x2203;</span><span 
+class="zptmcm7y-x-x-120">Â¬&#x2203;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
 class="zptmcm7m-x-x-120">O</span><span 
@@ -2289,7 +2289,7 @@ class="align-odd"><span
 class="zptmcm7y-x-x-120">&#x2203;</span><span 
 class="zptmcm7m-x-x-120">y </span><span 
 class="zptmcm7t-x-x-120">: [</span><span 
-class="zptmcm7y-x-x-120">¬&#x2203;</span><span 
+class="zptmcm7y-x-x-120">Â¬&#x2203;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
 class="zptmcm7m-x-x-120">O</span><span 
@@ -2338,7 +2338,7 @@ but slightly enhanced:
       <li class="itemize">If <span 
 class="zptmcm7m-x-x-120">&#x03D5; </span>is a wff, so are (<span 
 class="zptmcm7m-x-x-120">&#x03D5;</span>) and <span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span>.
       </li>
       <li class="itemize">If <span 
@@ -2391,7 +2391,7 @@ these two statements have different truth values in our Beatles example:
 class="align">
                                   <tr><td 
 class="align-odd"><span 
-class="zptmcm7y-x-x-120">¬&#x2203;</span><span 
+class="zptmcm7y-x-x-120">Â¬&#x2203;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
 class="zptmcm7m-x-x-120">L</span><span 
@@ -2406,7 +2406,7 @@ class="align-odd"><span
 class="zptmcm7y-x-x-120">&#x2203;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">L</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
@@ -2429,7 +2429,7 @@ same thing (that no Beatle is left-handed):
 class="align">
                                   <tr><td 
 class="align-odd"><span 
-class="zptmcm7y-x-x-120">¬&#x2203;</span><span 
+class="zptmcm7y-x-x-120">Â¬&#x2203;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
 class="zptmcm7m-x-x-120">L</span><span 
@@ -2444,7 +2444,7 @@ class="align-odd"><span
 class="zptmcm7y-x-x-120">&#x2200;</span><span 
 class="zptmcm7m-x-x-120">x </span><span 
 class="zptmcm7t-x-x-120">: </span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">L</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
@@ -2565,7 +2565,7 @@ class="zptmcm7m-x-x-120">X</span><span
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
 class="zptmcm7t-x-x-120">) </span><span 
-class="zptmcm7y-x-x-120">&#x2192;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2192;Â¬</span><span 
 class="zptmcm7m-x-x-120">Y </span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
@@ -2601,7 +2601,7 @@ class="zptmcm7m-x-x-120">X</span><span
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
 class="zptmcm7t-x-x-120">)</span><span 
-class="zptmcm7y-x-x-120">&#x2227;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2227;Â¬</span><span 
 class="zptmcm7m-x-x-120">Y </span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
@@ -2688,7 +2688,7 @@ class="zptmcm7m-x-x-120">P</span><span
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">x</span><span 
 class="zptmcm7t-x-x-120">) </span><span 
-class="zptmcm7y-x-x-120">&#x2194;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2194;Â¬</span><span 
 class="zptmcm7m-x-x-120">P</span><span 
 class="zptmcm7t-x-x-120">(</span><span 
 class="zptmcm7m-x-x-120">y</span><span 
@@ -2757,9 +2757,9 @@ class="align">
 class="align-odd"><span 
 class="msam-10x-x-120">&#x2662;</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
-class="zptmcm7y-x-x-120">&#x2194;¬</span><span 
+class="zptmcm7y-x-x-120">&#x2194;Â¬</span><span 
 class="msam-10x-x-120">&#x25A1;</span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span></td>                                <td 
 class="align-even"></td>                                <td 
 class="align-label"><a 
@@ -2774,12 +2774,12 @@ or
 class="align">
                                 <tr><td 
 class="align-odd"><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="msam-10x-x-120">&#x2662;</span><span 
 class="zptmcm7m-x-x-120">&#x03D5; </span><span 
 class="zptmcm7y-x-x-120">&#x2194;</span><span 
 class="msam-10x-x-120">&#x25A1;</span><span 
-class="zptmcm7y-x-x-120">¬</span><span 
+class="zptmcm7y-x-x-120">Â¬</span><span 
 class="zptmcm7m-x-x-120">&#x03D5;</span></td>                                <td 
 class="align-even"></td>                                <td 
 class="align-label"><a 
@@ -2969,15 +2969,15 @@ such a system is possible. At the International Congress of Mathematicians in Pa
 1900, the great German mathematician David Hilbert (1862&#8211;1943) famously
 proposed it as one of twenty-three open, unsolved problems for twentieth-century
 mathematics.
-<!--l. 815--><p class="indent" >  Thirty-one years later, the mathematician Kurt Gödel (1906&#8211;1978) gave an
+<!--l. 815--><p class="indent" >  Thirty-one years later, the mathematician Kurt GÃ¶del (1906&#8211;1978) gave an
 answer that pointed to a deep fundamental truth about the nature of mathematics. It
 remains one of the most startling results ever proposed by a mathematician, and has
 been the source of much (occasionally facile) musing among philosophers ever
 since.
 <!--l. 817--><p class="indent" >  The answer to that key question, you see, was &#8220;No.&#8221;
   <h4 class="subsectionHead"><span class="titlemark">1.3.3</span>&#x00A0;&#x00A0;<a 
- id="x1-220001.3.3"></a>The Greatest Hits of Kurt Gödel</h4>
-<!--l. 821--><p class="noindent" >To understand the full significance of Gödel&#8217;s theorems, we have to go back to Russell.
+ id="x1-220001.3.3"></a>The Greatest Hits of Kurt GÃ¶del</h4>
+<!--l. 821--><p class="noindent" >To understand the full significance of GÃ¶del&#8217;s theorems, we have to go back to Russell.
 Russell, motivated in part by his own paradox, undertook to write a colossal work that
 would set mathematics on a firm foundation once and for all. The machinery he employed
 was cumbersome and hard to understand, the notation verged on the inscrutable,
@@ -3003,19 +3003,19 @@ class="ptmri8t-x-x-120">couldn&#8217;t </span>be proven to be either true or
 false?
 <!--l. 825--><p class="noindent" >
   <h5 class="subsubsectionHead"><a 
- id="x1-230001.3.3"></a>Gödel&#8217;s Findings</h5>
-<!--l. 827--><p class="noindent" >Gödel was able to address this question directly in a way that shattered the entire program
+ id="x1-230001.3.3"></a>GÃ¶del&#8217;s Findings</h5>
+<!--l. 827--><p class="noindent" >GÃ¶del was able to address this question directly in a way that shattered the entire program
 in a series of three very famous and influential statements.
-<!--l. 830--><p class="indent" >  Gödel&#8217;s <span 
+<!--l. 830--><p class="indent" >  GÃ¶del&#8217;s <span 
 class="ptmb8t-x-x-120">Completeness Theorem</span><a 
  id="dx1-23001"></a> showed that <a 
  id="dx1-23002"></a><span 
 class="ptmb8t-x-x-120">first-order predicate logic </span>was complete
 (it had long been known to be sound). Unfortunately, first-order predicate logic itself was
-not expressive enough to support the whole of mathematics, and in fact, Gödel&#8217;s proof of
+not expressive enough to support the whole of mathematics, and in fact, GÃ¶del&#8217;s proof of
 his Completeness Theorem couldn&#8217;t be expressed in first-order predicate logic. He needed
 to use something stronger.
-<!--l. 832--><p class="indent" >  Gödel&#8217;s <span 
+<!--l. 832--><p class="indent" >  GÃ¶del&#8217;s <span 
 class="ptmb8t-x-x-120">First Incompleteness Theorem</span><a 
  id="dx1-23003"></a> showed that any formal system of logic
 powerful enough to support mathematics&#8212;or arithmetic, for that matter&#8212;had to be either
@@ -3023,7 +3023,7 @@ incomplete or unsound, and specifically inconsistent. He was able to construct a
 statement and show that if that statement was provable, so was its opposite. Therefore,
 either both statements were provable (meaning the system was unsound and inconsistent)
 or neither were (and the system was incomplete).
-<!--l. 834--><p class="indent" >  Gödel&#8217;s <span 
+<!--l. 834--><p class="indent" >  GÃ¶del&#8217;s <span 
 class="ptmb8t-x-x-120">Second Incompleteness Theorem</span><a 
  id="dx1-23004"></a> showed that it is not possible for a consistent
 system powerful enough for arithmetic to prove its own consistency, or alternatively, that
@@ -3031,12 +3031,12 @@ any system capable of proving its own consistency is inconsistent (making the pr
 wrong).
 <!--l. 836--><p class="noindent" >
   <h5 class="subsubsectionHead"><a 
- id="x1-240001.3.3"></a>What Gödel Really Found</h5>
+ id="x1-240001.3.3"></a>What GÃ¶del Really Found</h5>
 <!--l. 838--><p class="noindent" >Obviously, one can&#8217;t summarize in a few paragraphs or pages all the implications of some
 of the most profound results in the history of mathematical logic. But some discussion
 is needed, if for no other reason than to cut through some of the philosophical
 misunderstandings that have grown up around these theorems.
-<!--l. 844--><p class="indent" >  The Completeness Theorem is actually fairly straightforward. Essentially, Gödel
+<!--l. 844--><p class="indent" >  The Completeness Theorem is actually fairly straightforward. Essentially, GÃ¶del
 was able to show that first-order logic did really reflect the inherent idea of the
 possible-world semantics defined earlier, and that if one formalizes the idea of
 &#8220;possible worlds&#8221; strictly in terms of constants and (first-order) predicates, any
@@ -3044,7 +3044,7 @@ statement true in all possible worlds can be proven using the machinery of first
 logic.
 <!--l. 852--><p class="indent" >  The First Incompleteness Theorem however, shows that if we permit second-order and
 higher predicates, it is possible to generate paradoxes within the system. The paradox that
-Gödel was able to generate is a variation on a very old paradox called the <a 
+GÃ¶del was able to generate is a variation on a very old paradox called the <a 
  id="dx1-24001"></a><span 
 class="ptmb8t-x-x-120">Liar</span>
 <span 
@@ -3062,7 +3062,7 @@ form:
 false, then it must be the case that the sentence is not false, i.e., true. Either way, the
 assumption that the sentence is true or false yields a contradiction, so the sentence is
 paradoxical.
-<!--l. 865--><p class="indent" >  Gödel was able to construct a similar proposition that stated:
+<!--l. 865--><p class="indent" >  GÃ¶del was able to construct a similar proposition that stated:
       <ul class="itemize1">
       <li class="itemize">This sentence is not provable (in this logical system)</li></ul>
 <!--l. 871--><p class="noindent" >Obviously, if the sentence can be proved, then it must be true. But if it is true, then it can&#8217;t
@@ -3099,15 +3099,15 @@ few unprovable statements lends a sort of contrastive credence to what we <span
 class="ptmri8t-x-x-120">can</span>
 prove.
 <!--l. 879--><p class="indent" >  These results were hugely influential within the mathematics community, as
-one might expect. Gödel himself is often considered to be one of the greatest
+one might expect. GÃ¶del himself is often considered to be one of the greatest
 mathematicians of the twentieth century (if not of all time). But precisely because of the
 revolutionary nature of these findings, his theorems have been enlisted (at times, by
 otherwise reputable thinkers) in the project of making broad claims about the
 limitations of science, language, computers, and the human mind. Much of this
-is fatuous in large part because Gödel&#8217;s theorems have mostly narrow practical
+is fatuous in large part because GÃ¶del&#8217;s theorems have mostly narrow practical
 implications and are concerned exclusively with the limitations of mathematical
 logic.
-<!--l. 881--><p class="indent" >  But even if the implications of Gödel&#8217;s theorem were, within a broad philosophical
+<!--l. 881--><p class="indent" >  But even if the implications of GÃ¶del&#8217;s theorem were, within a broad philosophical
 perspective, somewhat narrow, the larger cultural implications remain. Hilbert had
 announced his &#8220;unsolved problems&#8221; with all the faith and high-minded exuberance of the
 nineteenth century:
@@ -3123,7 +3123,7 @@ href="#Xhilbert:mathematical">6</a>]</span></div>
 <!--l. 887--><p class="noindent" >Within a few decades, the centuries-old humanistic program that had begun with the
 Enlightenment (itself an era of profound mathematical insight and progress) would give
 way to a far more skeptical vision of human possibility. If Newton&#8217;s calculus had
-metaphorically typified the Age of Reason, so Gödel&#8217;s theorem would come to
+metaphorically typified the Age of Reason, so GÃ¶del&#8217;s theorem would come to
 represent the problematic aspirations of the Atomic Age. It wasn&#8217;t that logic had its
 limitations (not even the most naive medieval scholastic had doubted that). It was
 that for the mightiest of all reasoning systems&#8212;mathematics&#8212;it could never be
@@ -3133,35 +3133,35 @@ otherwise.
 
   <h2 class="chapterHead"><span class="titlemark">2</span>&#x00A0;&#x00A0;<a 
  id="x1-250002"></a>Discrete Mathematics</h2>
-<!--l. 4--><p class="noindent" >The Hungarian mathematician Paul Erdös (1913&#8211;1996) spent most of his adult life
+<!--l. 4--><p class="noindent" >The Hungarian mathematician Paul ErdÃ¶s (1913&#8211;1996) spent most of his adult life
 traveling from one university to another, working on mathematical problems with friends
 and colleagues, and living out of a suitcase that contained nearly all of his worldly
 possessions. One of mathematics&#8217;s most legendary eccentrics (and that is saying
-something), Erdös has the distinction of being the most prolific mathematician in
+something), ErdÃ¶s has the distinction of being the most prolific mathematician in
 history&#8212;the author of over fifteen-hundred papers in areas that range over most of the
 subjects in this book.
-<!--l. 6--><p class="indent" >  As a tribute to Erdös, the custom emerged of assigning &#8220;Erdös numbers&#8221; to research
-mathematicians. A mathematician who co-authored a paper directly with Erdös (an honor
-held by over five hundred people) is assigned an Erdös number of 1. People who have
-collaborated with a member of this group (but not with Erdös himself) have an Erdös
+<!--l. 6--><p class="indent" >  As a tribute to ErdÃ¶s, the custom emerged of assigning &#8220;ErdÃ¶s numbers&#8221; to research
+mathematicians. A mathematician who co-authored a paper directly with ErdÃ¶s (an honor
+held by over five hundred people) is assigned an ErdÃ¶s number of 1. People who have
+collaborated with a member of this group (but not with ErdÃ¶s himself) have an ErdÃ¶s
 number of 2. If you collaborated with someone who collaborated with someone who has a
 1, you&#8217;re a 3 (and so on).
-<!--l. 8--><p class="indent" >  Having a low Erdös number makes for good bragging rights, and some have suggested that
+<!--l. 8--><p class="indent" >  Having a low ErdÃ¶s number makes for good bragging rights, and some have suggested that
 such proximity to the well known may serve as a reasonable indicator of importance within a
 given field.<span class="footnote-mark"><a 
 href="main10.html#fn1x2"><sup class="textsuperscript">1</sup></a></span><a 
  id="x1-25001f1"></a>
-What is most fascinating, however, is the fact that the average Erdös number is less than 5.
-This suggests that the network formed by the group who have Erdös numbers exhibits what
+What is most fascinating, however, is the fact that the average ErdÃ¶s number is less than 5.
+This suggests that the network formed by the group who have ErdÃ¶s numbers exhibits what
 is sometimes called the &#8220;small world&#8221; phenomenon. The network itself is quite large, and
 most of the people in the network are not neighbors. Yet it only takes a few hops to get
 from one node to another. The game known as &#8220;Six Degrees of Kevin Bacon&#8221;&#8212;a variant of
-the Erdös-number concept in which one tries to form connections between actors who
+the ErdÃ¶s-number concept in which one tries to form connections between actors who
 have appeared in a movie with Kevin Bacon&#8212;also demonstrates the concept.
-As with Erdös numbers, the strange thing is how easy it is to find a connection;
+As with ErdÃ¶s numbers, the strange thing is how easy it is to find a connection;
 even moderately knowledgable movie buffs can &#8220;win&#8221; the game with relative
 ease.
-<!--l. 10--><p class="indent" >  Speaking of small worlds: It was one of Erdös&#8217;s countrymen, the Hungarian
+<!--l. 10--><p class="indent" >  Speaking of small worlds: It was one of ErdÃ¶s&#8217;s countrymen, the Hungarian
 fiction writer Frigyes Karinthy (1887&#8211;1938), who appears to have been the
 first to suggest that everyone in the entire world is connected by &#8220;six degrees
 of separation.&#8221; He put this idea forth in a 1929 short story entitled &#8220;Chains,&#8221; in
@@ -3198,7 +3198,7 @@ also the world&#8217;s leading source of games and puzzles (and therefore, an ob
 for students of games and game mechanics). Problems in discrete mathematics often come
 down to gaining some insight into the nature of a system. And when you have that
 insight, it can feel like you just figured out a trick or discovered a secret. People
-work out their Erdös numbers and determine how close an actress is to Kevin
+work out their ErdÃ¶s numbers and determine how close an actress is to Kevin
 Bacon because it&#8217;s fun. Yet it is also possible to ask whether everyone in the world
 really <span 
 class="ptmri8t-x-x-120">is </span>separated by only a few nodes in a vast network&#8212;a property of the social
@@ -4820,8 +4820,8 @@ actual football fan) would be happy to volunteer their services in pursuit of th
 goal.
   <h4 class="subsectionHead"><span class="titlemark">2.3.5</span>&#x00A0;&#x00A0;<a 
  id="x1-400002.3.5"></a>Eulerian Graphs</h4>
-<!--l. 415--><p class="noindent" >A famous early problem in graph theory is the &#8220;Bridges of Königsberg,&#8221; posed and solved
-by Leonhard Euler (1707&#8211;1783) in 1736. The city of Königsberg (now Kaliningrad)
+<!--l. 415--><p class="noindent" >A famous early problem in graph theory is the &#8220;Bridges of KÃ¶nigsberg,&#8221; posed and solved
+by Leonhard Euler (1707&#8211;1783) in 1736. The city of KÃ¶nigsberg (now Kaliningrad)
 straddles the Pregolya River&#8212;including a couple of islands in the middle of the river&#8212;and
 in 1736 there were seven major bridges crossing it. Figure&#x00A0;<a 
 href="#x1-400038">2.8<!--tex4ht:ref: fig:bridgesmap --></a> shows a crude map of the
@@ -4847,7 +4847,7 @@ src="images/bridges.png" alt="PIC"
 width="133" height="144" >
 <br /> <div class="caption"><table class="caption" 
 ><tr style="vertical-align:baseline;" class="caption"><td class="id">Figure&#x00A0;2.8: </td><td  
-class="content">Map of Königsberg and equivalent graph </td></tr></table></div><!--tex4ht:label?: x1-400038 -->
+class="content">Map of KÃ¶nigsberg and equivalent graph </td></tr></table></div><!--tex4ht:label?: x1-400038 -->
 <!--l. 424--><p class="indent" >  </div><hr class="endfigure">
 <!--l. 426--><p class="indent" >  According to mathematical legend, the local citizens liked to take walks about the city
 and wondered whether it was possible to take a walk that crossed each bridge once and only
@@ -4946,9 +4946,9 @@ class="ptmb8t-x-x-120">Hamiltonian</span>
 class="ptmb8t-x-x-120">graph</span>.<span class="footnote-mark"><a 
 href="main17.html#fn8x2"><sup class="textsuperscript">8</sup></a></span><a 
  id="x1-41002f8"></a>
-For Königsberg, this would mean that you only need to go to the central island once, and
+For KÃ¶nigsberg, this would mean that you only need to go to the central island once, and
 you don&#8217;t need to worry about how many different bridges there are. It&#8217;s not hard to show
-that Königsberg is Hamiltonian; start on the north shore (<span 
+that KÃ¶nigsberg is Hamiltonian; start on the north shore (<span 
 class="zptmcm7m-x-x-120">A</span>), then visit <span 
 class="zptmcm7m-x-x-120">B</span>, <span 
 class="zptmcm7m-x-x-120">D</span>, and <span 
@@ -5407,14 +5407,14 @@ big problem from the smaller answers. (Sometimes computer programmers will
 call this a &#8220;divide and conquer&#8221; approach, because it&#8217;s easier to solve several
 small problems and combine their answers than it is to solve the big problem
 directly).
-<!--l. 571--><p class="indent" >  The idea of an Erdös number, introduced earlier, is another example of a problem that
-can be solved using the idea of recursion. If you want to know what your Erdös number is,
+<!--l. 571--><p class="indent" >  The idea of an ErdÃ¶s number, introduced earlier, is another example of a problem that
+can be solved using the idea of recursion. If you want to know what your ErdÃ¶s number is,
 you could start with Paul himself, read all of his papers, make a list of all of his co-authors,
 then read all of their papers and make a list of all of their co-authors, continue through their
 co-co-authors, and so forth.
 <!--l. 573--><p class="indent" >  Or, you could take a more recursive approach: Approach all of your co-authors
-and ask them for their Erdös numbers. The idea, of course, is that anyone who
-has an Erdös number of 1 knows it, since they&#8217;ve co-written with Paul. That&#8217;s
+and ask them for their ErdÃ¶s numbers. The idea, of course, is that anyone who
+has an ErdÃ¶s number of 1 knows it, since they&#8217;ve co-written with Paul. That&#8217;s
 pretty obvious and easy. So if one of your coauthors says &#8220;my number is a 1,&#8221;
 then you know that your number is a 2. But more generally, if they don&#8217;t know
 what their number is, then they can ask their co-authors, and their co-authors can
@@ -5424,7 +5424,7 @@ co-author Christopher Hall is a 3. This makes Patrick a 4, and by extension Stev
 5.)<span class="footnote-mark"><a 
 href="main20.html#fn11x2"><sup class="textsuperscript">11</sup></a></span><a 
  id="x1-46005f11"></a>
-We therefore have a recursive definition of Erdös numbers. If you have written a paper with
+We therefore have a recursive definition of ErdÃ¶s numbers. If you have written a paper with
 Paul, your number is a one. Otherwise, your number is one more than the smallest number
 of any of your co-authors.
 <!--l. 575--><p class="indent" >  As another example, consider a simple safe with a programmable numeric keypad. One
@@ -6677,7 +6677,7 @@ played amid a set of interlocking triangles or on the surface of a sphere? Are t
 games that are reducible to the essential structure of sudoku (despite seeming entirely
 unrelated)?
 <!--l. 98--><p class="indent" >  Insight into essential relationship&#8212;the quest for those things that do not vary among
-outward forms&#8212;has often been the source of great breakthroughs in mathematics. René
+outward forms&#8212;has often been the source of great breakthroughs in mathematics. RenÃ©
 Descartes (1596&#8211;1650) provided one of the more striking examples in his work with the
 coordinate system that bears his name (Cartesian coordinates). Before Descartes, geometry
 and arithmetic were studied separately, and the properties of geometric objects like
@@ -11530,7 +11530,7 @@ class="content"> 60,000 simulated rolls of a realistically fair die</td></tr></t
 <!--l. 467--><p class="indent" >  Another important distribution with its own name is the <a 
  id="dx1-74004"></a><span 
 class="ptmb8t-x-x-120">Poisson distribution</span>, named
-after Siméon-Denis Poisson (1781&#8211;1840). The classic formulation is that of Ladislaus von
+after SimÃ©on-Denis Poisson (1781&#8211;1840). The classic formulation is that of Ladislaus von
 Bortkiewicz (1868&#8211;1931), who identified this distribution in the statistics of army officers
 kicked to death by horses. Obviously, there can never be fewer than zero deaths in such a
 manner, and the statistics suggest an average (based on von Bortkiewicz&#8217;s data, see
@@ -11687,7 +11687,7 @@ government that new taxes will adversely affect our poverty-ridden community. Bu
 income &#8220;normally distributed?&#8221; Suppose that in my mostly middle-class town, there&#8217;s one
 billionaire. This is a pretty good description of the street in Oxfordshire where
 one of the authors once lived. The &#8220;billionaire&#8221; was Richard Branson (of Virgin
-Records fame). The median income was probably less than £30,000, but the &#8220;mean&#8221;
+Records fame). The median income was probably less than Â£30,000, but the &#8220;mean&#8221;
 income&#8212;because of the influence of the outlier&#8212;might have been ten times that.
 Living near Richard Branson will inflate the mean income of the area, but not the
 median.
@@ -14045,12 +14045,12 @@ infinitely more functions. We therefore reach the unavoidable, if slightly uncom
 conclusion that &#8220;infinity&#8221; comes in different sizes. We can therefore speak of larger and
 smaller &#8220;infinities.&#8221;
 <!--l. 180--><p class="indent" >  The reaction to this work from Cantor&#8217;s fellow mathematicians was not, shall we say,
-charitable. Like Gödel&#8217;s theorem decades later, Cantor&#8217;s ideas tended to overturn much
-thinking about mathematics itself. But while Gödel&#8217;s theory caused a good deal of unease,
+charitable. Like GÃ¶del&#8217;s theorem decades later, Cantor&#8217;s ideas tended to overturn much
+thinking about mathematics itself. But while GÃ¶del&#8217;s theory caused a good deal of unease,
 it was nonetheless conceded to be correct. Cantor&#8217;s ideas&#8212;which included, among other
 things, a proof that there were as many points on the plane formed by the unit square as
 there are on one of the lines that makes up the square&#8217;s sides&#8212;were greeted in
-some quarters as a kind of heresy. Henri Poincaré (1854&#8211;1912) likened Cantor&#8217;s
+some quarters as a kind of heresy. Henri PoincarÃ© (1854&#8211;1912) likened Cantor&#8217;s
 ideas to a disease infecting mathematics; Ludwig Wittgenstein (1889&#8211;1951), who
 took a dim view of set theory in general, considered it laughable nonsense. The
 otherwise brilliant Leopold Kronecker (1823&#8211;1891) not only accused Cantor
@@ -18861,7 +18861,7 @@ minute change would rapidly multiply until the solution was not just inaccurate,
 but of a completely different form. This tiny change&#8212;in fact, almost any tiny
 change&#8212;seemed to cross into a different basin of attraction and follow a different
 attractor.
-<!--l. 595--><p class="indent" >  A similar problem had been identified earlier in the work of Poincaré on the three-body
+<!--l. 595--><p class="indent" >  A similar problem had been identified earlier in the work of PoincarÃ© on the three-body
 problem. The two-body problem (solved by Newton and his contemporaries) is a classic
 problem in mathematical astronomy; given two bodies, determine the paths that they will
 follow due to the mutual influence of gravity. However, if you add a third body into
@@ -18917,7 +18917,7 @@ class="newline" /><span
 class="ptmri8t-x-x-120">For want of a battle the kingdom was lost. </span><br 
 class="newline" /><span 
 class="ptmri8t-x-x-120">And all for the want of a horseshoe nail.</span></div>
-<!--l. 618--><p class="indent" >  Chaos theory has joined Gödel&#8217;s ideas about &#8220;incompleteness&#8221; and Heisenberg&#8217;s ideas
+<!--l. 618--><p class="indent" >  Chaos theory has joined GÃ¶del&#8217;s ideas about &#8220;incompleteness&#8221; and Heisenberg&#8217;s ideas
 about &#8220;uncertainty&#8221; as one of those abstruse mathematical ideas that has managed to
 capture the popular imagination. As with earlier instances, the emphasis is often
 placed on what mathematics (or physics, or computers) cannot do. But in all of
@@ -19176,7 +19176,7 @@ class="zptmcm7m-x-x-120">b</span>
       </li>
       <li class="itemize"><span 
 class="zptmcm7m-x-x-120">a</span><span 
-class="zptmcm7y-x-x-120">÷</span><span 
+class="zptmcm7y-x-x-120">Ã·</span><span 
 class="zptmcm7m-x-x-120">b </span><span 
 class="zptmcm7t-x-x-120">= </span><span 
 class="zptmcm7m-x-x-120">a&#x2215;b </span><span 
@@ -19211,7 +19211,7 @@ bd"  class="frac" align="middle">
 class="zptmcm7t-x-x-120">(</span><img 
 src="main307x.png" alt="ab"  class="frac" align="middle"><span 
 class="zptmcm7t-x-x-120">)</span><span 
-class="zptmcm7y-x-x-120">÷</span><span 
+class="zptmcm7y-x-x-120">Ã·</span><span 
 class="zptmcm7t-x-x-120">(</span><img 
 src="main308x.png" alt="dc"  class="frac" align="middle"><span 
 class="zptmcm7t-x-x-120">) = (</span><img 
@@ -19980,7 +19980,7 @@ class="ptmri8t-x-x-120">The Complete Works of Aristotle</span>, chapter Physics.
 class="ptmri8t-x-x-120">Men of Mathematics: The Lives and Achievements of the Great</span>
      <span 
 class="ptmri8t-x-x-120">Mathematicians from Zeno to Poincar</span><span 
-class="ptmri8t-x-x-120">é</span>. Simon-Touchstone, New York, 1937.
+class="ptmri8t-x-x-120">Ã©</span>. Simon-Touchstone, New York, 1937.
      </p>
      <p class="bibitem" ><span class="biblabel">
   [3]<span class="bibsp">&#x00A0;&#x00A0;&#x00A0;</span></span><a 

--- a/main10.html
+++ b/main10.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main11.html
+++ b/main11.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main12.html
+++ b/main12.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main13.html
+++ b/main13.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main14.html
+++ b/main14.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main15.html
+++ b/main15.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main16.html
+++ b/main16.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main17.html
+++ b/main17.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main18.html
+++ b/main18.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main19.html
+++ b/main19.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main2.html
+++ b/main2.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main20.html
+++ b/main20.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main20.html
+++ b/main20.html
@@ -14,12 +14,12 @@
          <!--l. 573--><p class="indent" >    <span class="footnote-mark"><a 
  id="fn11x2"><sup class="textsuperscript">11 </sup></a></span><span 
 class="ptmr8t-">The people who watch over such matters (and there are such people) would probably insist that Erd</span><span 
-class="ptmr8t-">ös</span>
+class="ptmr8t-">Ã¶s</span>
           <span 
 class="ptmr8t-">numbers only apply to people who have co-written formal, mathematical papers, and not, for example,</span>
           <span 
 class="ptmr8t-">textbooks and introductory works. Given Erd</span><span 
-class="ptmr8t-">ös&#8217;s love for the &#8220;epsilons&#8221; (the conventional symbol</span>
+class="ptmr8t-">Ã¶s&#8217;s love for the &#8220;epsilons&#8221; (the conventional symbol</span>
           <span 
 class="ptmr8t-">for a small, positive quantity and the term he routinely used to designate children), we feel</span>
           <span 

--- a/main21.html
+++ b/main21.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main22.html
+++ b/main22.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main23.html
+++ b/main23.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main24.html
+++ b/main24.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main25.html
+++ b/main25.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main26.html
+++ b/main26.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main27.html
+++ b/main27.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main28.html
+++ b/main28.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main29.html
+++ b/main29.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main3.html
+++ b/main3.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main30.html
+++ b/main30.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main31.html
+++ b/main31.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main32.html
+++ b/main32.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main33.html
+++ b/main33.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main34.html
+++ b/main34.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main35.html
+++ b/main35.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main36.html
+++ b/main36.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main37.html
+++ b/main37.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main38.html
+++ b/main38.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main39.html
+++ b/main39.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main4.html
+++ b/main4.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main40.html
+++ b/main40.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main41.html
+++ b/main41.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main42.html
+++ b/main42.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main43.html
+++ b/main43.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main44.html
+++ b/main44.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main45.html
+++ b/main45.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main46.html
+++ b/main46.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main47.html
+++ b/main47.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main48.html
+++ b/main48.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main49.html
+++ b/main49.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main5.html
+++ b/main5.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main50.html
+++ b/main50.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main51.html
+++ b/main51.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main52.html
+++ b/main52.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main53.html
+++ b/main53.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main54.html
+++ b/main54.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main55.html
+++ b/main55.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main56.html
+++ b/main56.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main57.html
+++ b/main57.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main58.html
+++ b/main58.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main59.html
+++ b/main59.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main6.html
+++ b/main6.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main60.html
+++ b/main60.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main61.html
+++ b/main61.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main62.html
+++ b/main62.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main7.html
+++ b/main7.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main8.html
+++ b/main8.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 

--- a/main8.html
+++ b/main8.html
@@ -18,11 +18,11 @@ class="ptmr8t-">The notation we are describing is the most common, but there is 
 class="ptmr8t-">will sometimes use different symbols to express the same logical concept, either for intuitive clarity, or for</span>
         <span 
 class="ptmr8t-">more prosaic reasons (like the fact that the </span><span 
-class="zptmcm7y-">¬</span><span 
+class="zptmcm7y-">Â¬</span><span 
 class="ptmr8t-">key doesn&#8217;t appear on a standard keyboard). In many</span>
         <span 
 class="ptmr8t-">programming languages, the symbol &#8220;!&#8221; is used for </span><span 
-class="zptmcm7y-">¬</span><span 
+class="zptmcm7y-">Â¬</span><span 
 class="ptmr8t-">, the symbol &#8220;&amp;&amp;&#8221; for </span><span 
 class="zptmcm7y-">&#x2227;</span><span 
 class="ptmr8t-">, and the symbol &#8220;</span><span 

--- a/main9.html
+++ b/main9.html
@@ -2,7 +2,7 @@
   "http://www.w3.org/TR/html4/loose.dtd">  
 <html > 
 <head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"> 
+<meta charset="utf-8"> 
 <meta name="generator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <meta name="originator" content="TeX4ht (http://www.tug.org/tex4ht/)"> 
 <!-- html --> 


### PR DESCRIPTION
The first commit converts the relevant affected files to UTF-8 encoding, and the second sets the correct meta charset declaration for each file.

Note: the originals look fine on GitHub because GitHub is able to detect the encoding and render them appropriately.  Any browser could do the same, but when they're served from GitHub Pages the HTTP `content-type` header is set to 'text/html; charset=utf-8' (and can't be changed), and that's why they get mangled.